### PR TITLE
Fixes LESS error of no value being supplied by less file for background-size on navicon

### DIFF
--- a/assets/styles/less/layout.less
+++ b/assets/styles/less/layout.less
@@ -49,12 +49,12 @@ html {
     }
     a[href="#nav"] {
         background: url(@image-sprite) no-repeat 0 0;
-        background-size: @@image-sprite-size;
+        background-size: @image-sprite-size;
         float: left;
     }
     a[href="#search"] {
         background: url(@image-sprite) no-repeat 0 -2em;
-        background-size: @@image-sprite-size;
+        background-size: @image-sprite-size;
         float: right;
     }
 }
@@ -68,7 +68,7 @@ html {
         h1 {
             font-size: 1em;
             background: url(@image-sprite) no-repeat 0 -4em;
-            background-size: @@image-sprite-size;
+            background-size: @image-sprite-size;
             margin: 0.375em 0;
             width: 2em;
             height: 2em;


### PR DESCRIPTION
Removed the extra `@` on the `@@image-sprite-size;` less variable. 

`[role="banner"]` now outputs a value for background-size.
